### PR TITLE
Fix crash after armory update

### DIFF
--- a/CSPracc/Modes/BaseMode/BaseMode.cs
+++ b/CSPracc/Modes/BaseMode/BaseMode.cs
@@ -31,9 +31,9 @@ namespace CSPracc.Modes
         protected GuiManager GuiManager { get; set; }
 
         protected  BaseEventHandler EventHandler { get; set; }
-        public  virtual void ConfigureEnvironment(bool hotReload = false)
+        public  virtual void ConfigureEnvironment(bool hotReload = true)
         {
-            if(!hotReload)
+            if(hotReload)
             {
                 DataModules.Constants.Methods.MsgToServer("Restoring default config.");
                 Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");

--- a/CSPracc/Modes/BaseMode/BaseMode.cs
+++ b/CSPracc/Modes/BaseMode/BaseMode.cs
@@ -31,11 +31,14 @@ namespace CSPracc.Modes
         protected GuiManager GuiManager { get; set; }
 
         protected  BaseEventHandler EventHandler { get; set; }
-        public  virtual void ConfigureEnvironment()
+        public  virtual void ConfigureEnvironment(bool hotReload = false)
         {
-            DataModules.Constants.Methods.MsgToServer("Restoring default config.");
-            Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
-            Server.ExecuteCommand("exec server.cfg");
+            if(!hotReload)
+            {
+                DataModules.Constants.Methods.MsgToServer("Restoring default config.");
+                Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
+                Server.ExecuteCommand("exec server.cfg");
+            }
             EventHandler = new BaseEventHandler(CSPraccPlugin.Instance!, new BaseCommandHandler(this));           
         }
         public static void ChangeMap(CCSPlayerController player, string mapName)

--- a/CSPracc/Modes/DryRunMode/DryRunMode.cs
+++ b/CSPracc/Modes/DryRunMode/DryRunMode.cs
@@ -45,11 +45,14 @@ namespace CSPracc
             Server.ExecuteCommand("mp_warmup_end 1");
         }
 
-        public override void ConfigureEnvironment()
+        public override void ConfigureEnvironment(bool hotReload = false)
         {
-            DataModules.Constants.Methods.MsgToServer("Starting Dryrun Mode");
-            Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
-            Server.ExecuteCommand("exec CSPRACC\\5on5_warmup.cfg");
+            if(!hotReload)
+            {
+                DataModules.Constants.Methods.MsgToServer("Starting Dryrun Mode");
+                Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
+                Server.ExecuteCommand("exec CSPRACC\\5on5_warmup.cfg");
+            }
             EventHandler?.Dispose();
             EventHandler = new DryRunEventHandler(CSPraccPlugin.Instance!, new DryRunCommandHandler(this),this);
         }    

--- a/CSPracc/Modes/DryRunMode/DryRunMode.cs
+++ b/CSPracc/Modes/DryRunMode/DryRunMode.cs
@@ -45,9 +45,9 @@ namespace CSPracc
             Server.ExecuteCommand("mp_warmup_end 1");
         }
 
-        public override void ConfigureEnvironment(bool hotReload = false)
+        public override void ConfigureEnvironment(bool hotReload = true)
         {
-            if(!hotReload)
+            if(hotReload)
             {
                 DataModules.Constants.Methods.MsgToServer("Starting Dryrun Mode");
                 Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");

--- a/CSPracc/Modes/MatchMode/MatchMode.cs
+++ b/CSPracc/Modes/MatchMode/MatchMode.cs
@@ -306,11 +306,14 @@ namespace CSPracc
             }
         }
 
-        public override void ConfigureEnvironment()
+        public override void ConfigureEnvironment(bool hotReload = false)
         {
-            DataModules.Constants.Methods.MsgToServer("Loading match mode.");
-            Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
-            Server.ExecuteCommand("exec CSPRACC\\5on5_warmup.cfg");
+            if(!hotReload)
+            {
+                DataModules.Constants.Methods.MsgToServer("Loading match mode.");
+                Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
+                Server.ExecuteCommand("exec CSPRACC\\5on5_warmup.cfg");
+            }
             EventHandler?.Dispose();
             EventHandler = new MatchEventHandler(CSPraccPlugin.Instance!, new MatchCommandHandler(this),this);
             state = Enums.match_state.warmup;

--- a/CSPracc/Modes/MatchMode/MatchMode.cs
+++ b/CSPracc/Modes/MatchMode/MatchMode.cs
@@ -306,9 +306,9 @@ namespace CSPracc
             }
         }
 
-        public override void ConfigureEnvironment(bool hotReload = false)
+        public override void ConfigureEnvironment(bool hotReload = true)
         {
-            if(!hotReload)
+            if(hotReload)
             {
                 DataModules.Constants.Methods.MsgToServer("Loading match mode.");
                 Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");

--- a/CSPracc/Modes/PracticeMode/PracticeMode.cs
+++ b/CSPracc/Modes/PracticeMode/PracticeMode.cs
@@ -244,9 +244,9 @@ namespace CSPracc.Modes
             GuiManager.AddMenu(player.SteamID, projectileManager.GetNadeMenu(player));
         }
 
-        public override void ConfigureEnvironment(bool hotReload = false)
+        public override void ConfigureEnvironment(bool hotReload = true)
         {
-            if(!hotReload)
+            if(hotReload)
             {
                 DataModules.Constants.Methods.MsgToServer("Loading practice mode.");
                 Server.ExecuteCommand("exec CSPRACC\\pracc.cfg");

--- a/CSPracc/Modes/PracticeMode/PracticeMode.cs
+++ b/CSPracc/Modes/PracticeMode/PracticeMode.cs
@@ -244,10 +244,13 @@ namespace CSPracc.Modes
             GuiManager.AddMenu(player.SteamID, projectileManager.GetNadeMenu(player));
         }
 
-        public override void ConfigureEnvironment()
+        public override void ConfigureEnvironment(bool hotReload = false)
         {
-            DataModules.Constants.Methods.MsgToServer("Loading practice mode.");
-            Server.ExecuteCommand("exec CSPRACC\\pracc.cfg");
+            if(!hotReload)
+            {
+                DataModules.Constants.Methods.MsgToServer("Loading practice mode.");
+                Server.ExecuteCommand("exec CSPRACC\\pracc.cfg");
+            }
             EventHandler?.Dispose();
             EventHandler = new PracticeEventHandler(CSPraccPlugin.Instance!, new PracticeCommandHandler(this, ref projectileManager,ref PracticeBotManager, ref SpawnManager),ref projectileManager, ref PracticeBotManager);
         }

--- a/CSPracc/Modes/PrefireMode/PrefireMode.cs
+++ b/CSPracc/Modes/PrefireMode/PrefireMode.cs
@@ -253,9 +253,9 @@ namespace CSPracc.Modes
             }
         }
 
-        public override void ConfigureEnvironment(bool hotReload = false)
+        public override void ConfigureEnvironment(bool hotReload = true)
         {
-            if(!hotReload)
+            if(hotReload)
             {
                 DataModules.Constants.Methods.MsgToServer("Loading prefire mode.");
                 Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");

--- a/CSPracc/Modes/PrefireMode/PrefireMode.cs
+++ b/CSPracc/Modes/PrefireMode/PrefireMode.cs
@@ -253,20 +253,24 @@ namespace CSPracc.Modes
             }
         }
 
-        public override void ConfigureEnvironment()
+        public override void ConfigureEnvironment(bool hotReload = false)
         {
-            DataModules.Constants.Methods.MsgToServer("Loading prefire mode.");
-            Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
-            Server.ExecuteCommand("exec CSPRACC\\prefire.cfg");
+            if(!hotReload)
+            {
+                DataModules.Constants.Methods.MsgToServer("Loading prefire mode.");
+                Server.ExecuteCommand("exec CSPRACC\\undo_pracc.cfg");
+                Server.ExecuteCommand("exec CSPRACC\\prefire.cfg");
+
+                Utils.ServerMessage($"Use {ChatColors.Green}.routes{ChatColors.White} to show menu of routes.");
+                Utils.ServerMessage($"Use {ChatColors.Green}.addroute (routename){ChatColors.White} to add a empty route.");
+                Utils.ServerMessage($"Use {ChatColors.Green}.editroute (routename){ChatColors.White} to edit given route.");
+                Utils.ServerMessage($"Use {ChatColors.Green}.addspawn{ChatColors.White} to add spawn to current route.");
+                Utils.ServerMessage($"Use {ChatColors.Green}.startpoint{ChatColors.White} to set startpoint of current route.");
+                Utils.ServerMessage($"Use {ChatColors.Green}.next{ChatColors.White} to select next route of current map.");
+                Utils.ServerMessage($"Use {ChatColors.Green}.back{ChatColors.White} to go back to last route.");
+            }
             EventHandler?.Dispose();
             EventHandler = new PrefireEventHandler(CSPraccPlugin.Instance!, new PrefireCommandHandler(this),this);
-            Utils.ServerMessage($"Use {ChatColors.Green}.routes{ChatColors.White} to show menu of routes.");
-            Utils.ServerMessage($"Use {ChatColors.Green}.addroute (routename){ChatColors.White} to add a empty route.");
-            Utils.ServerMessage($"Use {ChatColors.Green}.editroute (routename){ChatColors.White} to edit given route.");
-            Utils.ServerMessage($"Use {ChatColors.Green}.addspawn{ChatColors.White} to add spawn to current route.");
-            Utils.ServerMessage($"Use {ChatColors.Green}.startpoint{ChatColors.White} to set startpoint of current route.");
-            Utils.ServerMessage($"Use {ChatColors.Green}.next{ChatColors.White} to select next route of current map.");
-            Utils.ServerMessage($"Use {ChatColors.Green}.back{ChatColors.White} to go back to last route.");
         }
     }
 }

--- a/CSPracc/Modes/RetakeMode/RetakeMode.cs
+++ b/CSPracc/Modes/RetakeMode/RetakeMode.cs
@@ -117,10 +117,13 @@ namespace CSPracc.Modes
             return HookResult.Continue;
         }
 
-        public override void ConfigureEnvironment()
+        public override void ConfigureEnvironment(bool hotReload = false)
         {
-            DataModules.Constants.Methods.MsgToServer("Loading retakes mode.");
-            Server.ExecuteCommand("exec CSPRACC\\retake.cfg");
+            if(!hotReload)
+            {
+                DataModules.Constants.Methods.MsgToServer("Loading retakes mode.");
+                Server.ExecuteCommand("exec CSPRACC\\retake.cfg");
+            }
             EventHandler?.Dispose();
             EventHandler = new RetakeEventHandler(CSPraccPlugin.Instance!, new RetakeCommandHandler(this),this);
         }

--- a/CSPracc/Modes/RetakeMode/RetakeMode.cs
+++ b/CSPracc/Modes/RetakeMode/RetakeMode.cs
@@ -117,9 +117,9 @@ namespace CSPracc.Modes
             return HookResult.Continue;
         }
 
-        public override void ConfigureEnvironment(bool hotReload = false)
+        public override void ConfigureEnvironment(bool hotReload = true)
         {
-            if(!hotReload)
+            if(hotReload)
             {
                 DataModules.Constants.Methods.MsgToServer("Loading retakes mode.");
                 Server.ExecuteCommand("exec CSPRACC\\retake.cfg");

--- a/CSPracc/PraccPlugin.cs
+++ b/CSPracc/PraccPlugin.cs
@@ -137,7 +137,7 @@ public class CSPraccPlugin : BasePlugin, IPluginConfig<CSPraccConfig>
                     break;
                 }               
         }
-        PluginMode?.ConfigureEnvironment();
+        PluginMode?.ConfigureEnvironment(true);
     }
 
     public void OnConfigParsed(CSPraccConfig config)

--- a/CSPracc/PraccPlugin.cs
+++ b/CSPracc/PraccPlugin.cs
@@ -84,7 +84,7 @@ public class CSPraccPlugin : BasePlugin, IPluginConfig<CSPraccConfig>
             Reset();
         });
         Instance = this;
-        SwitchMode(Config!.ModeToLoad);
+        SwitchMode(Config!.ModeToLoad, hotReload);
         Logger.LogInformation("Pracitce Plugin loaded.");
     }
 
@@ -96,7 +96,7 @@ public class CSPraccPlugin : BasePlugin, IPluginConfig<CSPraccConfig>
         SwitchMode(Config!.ModeToLoad);
     }
 
-    public static void SwitchMode(PluginMode pluginMode)
+    public static void SwitchMode(PluginMode pluginMode, bool hotReload = true)
     {
         PluginMode?.Dispose();
         switch (pluginMode)
@@ -137,7 +137,7 @@ public class CSPraccPlugin : BasePlugin, IPluginConfig<CSPraccConfig>
                     break;
                 }               
         }
-        PluginMode?.ConfigureEnvironment(true);
+        PluginMode?.ConfigureEnvironment(hotReload);
     }
 
     public void OnConfigParsed(CSPraccConfig config)


### PR DESCRIPTION
Crash happens when using methods inside `Server` too early